### PR TITLE
feat(api): make country and language models read-only

### DIFF
--- a/lib/src/registry/model_registry.dart
+++ b/lib/src/registry/model_registry.dart
@@ -188,7 +188,9 @@ final modelRegistry = <String, ModelConfig<dynamic>>{
   'country': ModelConfig<Country>(
     fromJson: Country.fromJson,
     getId: (c) => c.id,
-    // Countries: Admin-owned, read allowed by standard/guest users
+    // Countries: Static data, read-only for all authenticated users.
+    // Modification is not allowed via the API as this is real-world data
+    // managed by database seeding.
     getCollectionPermission: const ModelActionPermission(
       type: RequiredPermissionType.specificPermission,
       permission: Permissions.countryRead,
@@ -197,14 +199,32 @@ final modelRegistry = <String, ModelConfig<dynamic>>{
       type: RequiredPermissionType.specificPermission,
       permission: Permissions.countryRead,
     ),
+    postPermission: const ModelActionPermission(type: RequiredPermissionType.unsupported),
+    putPermission: const ModelActionPermission(type: RequiredPermissionType.unsupported),
+    deletePermission: const ModelActionPermission(type: RequiredPermissionType.unsupported),
+  ),
+  'language': ModelConfig<Language>(
+    fromJson: Language.fromJson,
+    getId: (l) => l.id,
+    // Languages: Static data, read-only for all authenticated users.
+    // Modification is not allowed via the API as this is real-world data
+    // managed by database seeding.
+    getCollectionPermission: const ModelActionPermission(
+      type: RequiredPermissionType.specificPermission,
+      permission: Permissions.languageRead,
+    ),
+    getItemPermission: const ModelActionPermission(
+      type: RequiredPermissionType.specificPermission,
+      permission: Permissions.languageRead,
+    ),
     postPermission: const ModelActionPermission(
-      type: RequiredPermissionType.adminOnly,
+      type: RequiredPermissionType.unsupported,
     ),
     putPermission: const ModelActionPermission(
-      type: RequiredPermissionType.adminOnly,
+      type: RequiredPermissionType.unsupported,
     ),
     deletePermission: const ModelActionPermission(
-      type: RequiredPermissionType.adminOnly,
+      type: RequiredPermissionType.unsupported,
     ),
   ),
   'user': ModelConfig<User>(

--- a/routes/api/v1/data/[id]/index.dart
+++ b/routes/api/v1/data/[id]/index.dart
@@ -107,6 +107,9 @@ Future<Response> _handleGet(
     case 'country':
       final repo = context.read<DataRepository<Country>>();
       item = await repo.read(id: id, userId: userIdForRepoCall);
+    case 'language':
+      final repo = context.read<DataRepository<Language>>();
+      item = await repo.read(id: id, userId: userIdForRepoCall);
     case 'user': // Handle User model specifically if needed, or rely on generic
       final repo = context.read<DataRepository<User>>();
       item = await repo.read(id: id, userId: userIdForRepoCall);
@@ -309,6 +312,15 @@ Future<Response> _handlePut(
           userId: userIdForRepoCall,
         );
       }
+    case 'language':
+      {
+        final repo = context.read<DataRepository<Language>>();
+        updatedItem = await repo.update(
+          id: id,
+          item: itemToUpdate as Language,
+          userId: userIdForRepoCall,
+        );
+      }
     case 'user':
       {
         final repo = context.read<DataRepository<User>>();
@@ -454,6 +466,9 @@ Future<Response> _handleDelete(
       case 'country':
         final repo = context.read<DataRepository<Country>>();
         itemToDelete = await repo.read(id: id, userId: userIdForRepoCall);
+      case 'language':
+        final repo = context.read<DataRepository<Language>>();
+        itemToDelete = await repo.read(id: id, userId: userIdForRepoCall);
       case 'user':
         final repo = context.read<DataRepository<User>>();
         itemToDelete = await repo.read(id: id, userId: userIdForRepoCall);
@@ -514,6 +529,11 @@ Future<Response> _handleDelete(
       );
     case 'country':
       await context.read<DataRepository<Country>>().delete(
+        id: id,
+        userId: userIdForRepoCall,
+      );
+    case 'language':
+      await context.read<DataRepository<Language>>().delete(
         id: id,
         userId: userIdForRepoCall,
       );


### PR DESCRIPTION
- Updates the model registry to configure `Country` and `Language` as read-only by marking POST, PUT, and DELETE operations as unsupported. This reflects that they are static, real-world data managed by seeding.
- Adds the `Language` model to the item-specific route handler (`/data/[id]`) to complete its integration, allowing individual languages to be fetched by ID.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
